### PR TITLE
166 dependency manage repo repo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Most sites will manage repositories seperately; however, this module can manage 
      }
 
 Note: When using this on Debian/Ubuntu you will need to add the [Puppetlabs/apt](http://forge.puppetlabs.com/puppetlabs/apt) module to your modules.
+If no repo_version is provided, default is set to 1.3.
 
 ## Service Management
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -178,7 +178,7 @@ class logstash(
   $init_defaults_file  = undef,
   $init_template       = undef,
   $manage_repo         = false,
-  $repo_version        = false,
+  $repo_version        = $logstash::params::repo_version,
   $install_contrib     = false,
   $repo_stage          = false
 ) inherits logstash::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,9 @@ class logstash::params {
   # package download timeout
   $package_dl_timeout = 600 # 300 seconds is default of puppet
 
+  # default version to use if non is provided when manage_repo is set to true
+  $repo_version = '1.3'
+
   #### Internal module values
 
   # User and Group for the files and user to run the service as.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,7 +53,7 @@ class logstash::params {
   $package_dl_timeout = 600 # 300 seconds is default of puppet
 
   # default version to use if non is provided when manage_repo is set to true
-  $repo_version = '1.3'
+  $repo_version = '1.4'
 
   #### Internal module values
 


### PR DESCRIPTION
Fix for the [issue 166](https://github.com/elasticsearch/puppet-logstash/issues/166). Fixed internal dependency between manage_repo and repo_version establishing default value for repo_version if non is provided. 