### PR TITLE
Update Readme according to code

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Most sites will manage repositories seperately; however, this module can manage 
      }
 
 Note: When using this on Debian/Ubuntu you will need to add the [Puppetlabs/apt](http://forge.puppetlabs.com/puppetlabs/apt) module to your modules.
-If no repo_version is provided, default is set to 1.3.
+If no repo_version is provided, default is set to 1.4.
 
 ## Service Management
 


### PR DESCRIPTION
According to the [manifest](https://github.com/elasticsearch/puppet-logstash/blob/74c5afb0d533d43f83341f4bf4871f96ea041eb0/manifests/params.pp#L56) default version is currently 1.4